### PR TITLE
Add source mapping highlighting

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2355,3 +2355,6 @@ label.checkbox,
   position: relative !important;
   right: 5px !important;
 }
+.cm-line-without-source-mapping {
+    background: #2F2F2F !important;
+}


### PR DESCRIPTION
When working with sourcemapping, the brogrammer theme appears to have no styling for lines without source mapping, which results in the following:  

![](http://i.imgur.com/ixQHFLm.png)  

After my fix:  

![](http://i.imgur.com/jlH27qm.png)
